### PR TITLE
Rename `type: help-wanted` to `help-wanted`

### DIFF
--- a/github-labels.json
+++ b/github-labels.json
@@ -5,6 +5,11 @@
     "description": "Good for newcomers"
   },
   {
+    "name": "help wanted",
+    "color": "008672",
+    "description": "Extra attention is needed"
+  },
+  {
     "name": "priority: critical",
     "color": "b60205",
     "description": ""
@@ -78,11 +83,6 @@
     "name": "type: feature request",
     "color": "fbca04",
     "description": "New feature or request"
-  },
-  {
-    "name": "type: help wanted",
-    "color": "008672",
-    "description": "Extra attention is needed"
   },
   {
     "name": "type: question",


### PR DESCRIPTION
With this we get compatibility with the suggestions of GitHub.

![screen-shot-2018-06-12-at-11 58 21](https://user-images.githubusercontent.com/1007051/41283982-53c30d8c-6e38-11e8-9b11-e08052baff6f.png)
