### PR TITLE
feat(label): add triage

### DIFF
--- a/github-labels.json
+++ b/github-labels.json
@@ -50,6 +50,11 @@
     "description": ""
   },
   {
+    "name": "status: needs triage",
+    "color": "fbca04",
+    "description": "This issue may need triage"
+  },
+  {
     "name": "status: wont do/fix",
     "color": "eeeeee",
     "description": "This will not be worked on"


### PR DESCRIPTION
Closes https://github.com/abdonrd/github-labels/issues/5

- I didn't update the image because I don't have the source file
- Wasn't sure if there was already a guideline regarding colors, so I just reused one.
